### PR TITLE
Add name attribute with id value for password generated element

### DIFF
--- a/jquery.password123.js
+++ b/jquery.password123.js
@@ -144,7 +144,7 @@
 				classes  = self.options.placeholder && place !== undefined && (value === place || value === '') ?
 								field.className + ' ' + self.options.placeholderClass :
 								field.className,
-				attrs = { 'class': classes, 'id': field_id, 'value': value, 'placeholder': self.options.placeholder ? undefined : place },
+				attrs = { 'class': classes, 'id': field_id, 'name': field_id, 'value': value, 'placeholder': self.options.placeholder ? undefined : place },
 				standards = [ 'size', 'tabindex', 'readonly', 'disabled', 'maxlength' ];
 
 			// Combine attrs with standard attrs


### PR DESCRIPTION
...e as id

In order to work with the jquery validation plugin, a name attribute is required.  I added the name attribute to use the same value as the id in the generated password field.
